### PR TITLE
[FEAT] 혼자 달리기 기능 

### DIFF
--- a/RunUs/RunUs/Utils/MapPage.swift
+++ b/RunUs/RunUs/Utils/MapPage.swift
@@ -12,7 +12,7 @@ struct MapPage: View {
     @StateObject var mapVM: MapViewModel = MapViewModel()
     
     var body: some View {
-        Map()
+        Map(mapVM: mapVM)
             .onAppear(perform: {
                 mapVM.checkLocationPermission()
             })
@@ -20,6 +20,11 @@ struct MapPage: View {
 }
 
 struct Map: UIViewRepresentable {
+    @ObservedObject var mapVM: MapViewModel
+    
+    init(mapVM: MapViewModel) {
+        self.mapVM = mapVM
+    }
     
     func makeUIView(context: Context) -> NMFNaverMapView {
         let map = NMFNaverMapView()
@@ -35,7 +40,16 @@ struct Map: UIViewRepresentable {
     }
     
     func updateUIView(_ uiView: UIViewType, context: Context) {
-        
+        let map = uiView.mapView
+        addPathOverlay(map)
+    }
+    
+    // 경로선 그리는 함수
+    func addPathOverlay(_ map: NMFMapView) {
+        let pathOverlay = NMFPath()
+        pathOverlay.color = .blue
+        pathOverlay.path = NMGLineString(points: mapVM.userPath)
+        pathOverlay.mapView = map
     }
 }
 

--- a/RunUs/RunUs/Utils/MapPage.swift
+++ b/RunUs/RunUs/Utils/MapPage.swift
@@ -25,11 +25,6 @@ struct Map: UIViewRepresentable {
     
     func makeUIView(context: Context) -> NMFNaverMapView {
         let map = NMFNaverMapView()
-        
-        // 사용자 위치로 지도 화면 이동
-        let cameraUpdate = NMFCameraUpdate(scrollTo: map.mapView.cameraPosition.target)
-        map.mapView.moveCamera(cameraUpdate)
-        
         map.showLocationButton = true
         map.mapView.positionMode = .direction
         
@@ -38,6 +33,11 @@ struct Map: UIViewRepresentable {
     
     func updateUIView(_ uiView: UIViewType, context: Context) {
         let map = uiView.mapView
+        
+        // 사용자 위치로 지도 화면 이동
+        let cameraUpdate = NMFCameraUpdate(scrollTo: NMGLatLng(from: mapVM.userLocation.coordinate))
+        map.moveCamera(cameraUpdate)
+        
         addPathOverlay(map)
     }
     

--- a/RunUs/RunUs/Utils/MapPage.swift
+++ b/RunUs/RunUs/Utils/MapPage.swift
@@ -23,7 +23,14 @@ struct Map: UIViewRepresentable {
     
     func makeUIView(context: Context) -> NMFNaverMapView {
         let map = NMFNaverMapView()
+        
+        // 사용자 위치로 지도 화면 이동
+        let cameraUpdate = NMFCameraUpdate(scrollTo: map.mapView.cameraPosition.target)
+        map.mapView.moveCamera(cameraUpdate)
+        
         map.showLocationButton = true
+        map.mapView.positionMode = .direction
+        
         return map
     }
     

--- a/RunUs/RunUs/Utils/MapPage.swift
+++ b/RunUs/RunUs/Utils/MapPage.swift
@@ -9,13 +9,10 @@ import NMapsMap
 import SwiftUI
 
 struct MapPage: View {
-    @StateObject var mapVM: MapViewModel = MapViewModel()
+    @StateObject var mapVM: MapViewModel
     
     var body: some View {
         Map(mapVM: mapVM)
-            .onAppear(perform: {
-                mapVM.checkLocationPermission()
-            })
     }
 }
 
@@ -54,5 +51,5 @@ struct Map: UIViewRepresentable {
 }
 
 #Preview {
-    MapPage()
+    MapPage(mapVM: MapViewModel())
 }

--- a/RunUs/RunUs/View/Run/RunAlonePage.swift
+++ b/RunUs/RunUs/View/Run/RunAlonePage.swift
@@ -13,6 +13,7 @@ enum RunningProgressStatus: String, CaseIterable {
 }
 
 struct RunAlonePage: View {
+    @StateObject var mapVM: MapViewModel = MapViewModel()
     @State private var selectedTab: Int = 0
     
     var body: some View {
@@ -28,17 +29,19 @@ struct RunAlonePage: View {
                 
                 switch (selectedTab) {
                 case 0:
-                    RunningProgressPage()
+                    RunningProgressPage(mapVM: mapVM)
                         .padding(.top, 50)
                 case 1:
-                    RunningMapPage()
+                    RunningMapPage(mapVM: mapVM)
                 default:
                     EmptyView()
                 }
             }
             .navigationBarBackButtonHidden()
         }
-        
+        .onAppear {
+            mapVM.startUpdatingLocation()
+        }
     }
 }
 

--- a/RunUs/RunUs/View/Run/RunAlonePage.swift
+++ b/RunUs/RunUs/View/Run/RunAlonePage.swift
@@ -36,7 +36,7 @@ struct RunAlonePage: View {
                     EmptyView()
                 }
             }
-            
+            .navigationBarBackButtonHidden()
         }
         
     }

--- a/RunUs/RunUs/View/Run/RunAlonePage.swift
+++ b/RunUs/RunUs/View/Run/RunAlonePage.swift
@@ -13,32 +13,27 @@ enum RunningProgressStatus: String, CaseIterable {
 }
 
 struct RunAlonePage: View {
-    @StateObject var mapVM: MapViewModel = MapViewModel()
+    @StateObject var mapVM: MapViewModel = .init()
     @State private var selectedTab: Int = 0
-    
+
     var body: some View {
-        GeometryReader { geometry in
-            VStack {
-                Picker("", selection: $selectedTab) {
-                    ForEach(RunningProgressStatus.allCases.indices, id: \.self) { index in
-                        Text(RunningProgressStatus.allCases[index].rawValue).tag(index)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .padding()
-                
-                switch (selectedTab) {
-                case 0:
-                    RunningProgressPage(mapVM: mapVM, selectedTab: $selectedTab)
-                        .padding(.top, 50)
-                case 1:
-                    RunningMapPage(mapVM: mapVM)
-                default:
-                    EmptyView()
+        VStack {
+            Picker("", selection: $selectedTab) {
+                ForEach(RunningProgressStatus.allCases.indices, id: \.self) { index in
+                    Text(RunningProgressStatus.allCases[index].rawValue).tag(index)
                 }
             }
-            .navigationBarBackButtonHidden()
+            .pickerStyle(.segmented)
+            .padding()
+
+            TabView(selection: $selectedTab) {
+                RunningProgressPage(mapVM: mapVM, selectedTab: $selectedTab)
+                    .tag(0)
+                RunningMapPage(mapVM: mapVM)
+                    .tag(1)
+            }
         }
+        .navigationBarBackButtonHidden()
         .onAppear {
             mapVM.startUpdatingLocation()
         }

--- a/RunUs/RunUs/View/Run/RunAlonePage.swift
+++ b/RunUs/RunUs/View/Run/RunAlonePage.swift
@@ -29,7 +29,7 @@ struct RunAlonePage: View {
                 
                 switch (selectedTab) {
                 case 0:
-                    RunningProgressPage(mapVM: mapVM)
+                    RunningProgressPage(mapVM: mapVM, selectedTab: $selectedTab)
                         .padding(.top, 50)
                 case 1:
                     RunningMapPage(mapVM: mapVM)

--- a/RunUs/RunUs/View/Run/RunningMapPage.swift
+++ b/RunUs/RunUs/View/Run/RunningMapPage.swift
@@ -16,15 +16,46 @@ struct RunningMapPage: View {
                 ZStack(alignment: .bottom) {
                     MapPage(mapVM: mapVM)
                         .frame(height: geometry.size.width)
-                    Button(action: {
-                        mapVM.stopUpdatingLocation()
-                    }, label: {
-                        Image(systemName: "pause.circle")
-                            .resizable()
-                            .frame(width: 70, height: 70)
-                            .foregroundStyle(.black)
-                    })
-                    .padding()
+                    
+                    // 일시정지 버튼
+                    if mapVM.isRunning {
+                        Button(action: {
+                            mapVM.stopUpdatingLocation()
+                            mapVM.isRunning = false
+                        }, label: {
+                            Image(systemName: "pause.circle")
+                                .resizable()
+                                .frame(width: 70, height: 70)
+                                .foregroundStyle(.black)
+                        })
+                        .padding()
+                    }
+                    // 계속하기&끝내기 버튼
+                    else {
+                        HStack {
+                            Spacer()
+                            Button {} label: {
+                                Text("끝내기")
+                                    .font(.body1)
+                                    .foregroundColor(.white)
+                            }
+                            .padding()
+                            .frame(width: geometry.size.width*0.35)
+                            .background(.black)
+                            Button {
+                                mapVM.isRunning = true
+                            } label: {
+                                Text("계속하기")
+                                    .font(.body1)
+                                    .foregroundColor(.black)
+                            }
+                            .padding()
+                            .frame(width: geometry.size.width*0.35)
+                            .background(.white)
+                        }
+                        .frame(height: 70)
+                        .padding()
+                    }
                 }
                 HStack {
                     VStack(spacing: 15) {

--- a/RunUs/RunUs/View/Run/RunningMapPage.swift
+++ b/RunUs/RunUs/View/Run/RunningMapPage.swift
@@ -8,13 +8,17 @@
 import SwiftUI
 
 struct RunningMapPage: View {
+    @StateObject var mapVM: MapViewModel
+    
     var body: some View {
         GeometryReader { geometry in
             VStack(spacing: 50) {
                 ZStack(alignment: .bottom) {
-                    MapPage()
+                    MapPage(mapVM: mapVM)
                         .frame(height: geometry.size.width)
-                    Button(action: {}, label: {
+                    Button(action: {
+                        mapVM.stopUpdatingLocation()
+                    }, label: {
                         Image(systemName: "pause.circle")
                             .resizable()
                             .frame(width: 70, height: 70)
@@ -48,5 +52,5 @@ struct RunningMapPage: View {
 }
 
 #Preview {
-    RunningMapPage()
+    RunningMapPage(mapVM: MapViewModel())
 }

--- a/RunUs/RunUs/View/Run/RunningProgressPage.swift
+++ b/RunUs/RunUs/View/Run/RunningProgressPage.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct RunningProgressPage: View {
+    @StateObject var mapVM: MapViewModel
+    
     var body: some View {
         VStack(spacing: 50) {
             VStack(spacing: 15) {
@@ -27,7 +29,9 @@ struct RunningProgressPage: View {
                 Text("0.4km")
                     .font(.title1)
             }
-            Button(action: {}, label: {
+            Button(action: {
+                mapVM.stopUpdatingLocation()
+            }, label: {
                 Image(systemName: "pause.circle")
                     .resizable()
                     .frame(width: 80, height: 80)
@@ -39,5 +43,5 @@ struct RunningProgressPage: View {
 }
 
 #Preview {
-    RunningProgressPage()
+    RunningProgressPage(mapVM: MapViewModel())
 }

--- a/RunUs/RunUs/View/Run/RunningProgressPage.swift
+++ b/RunUs/RunUs/View/Run/RunningProgressPage.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct RunningProgressPage: View {
     @StateObject var mapVM: MapViewModel
+    @Binding var selectedTab: Int
     
     var body: some View {
         VStack(spacing: 50) {
@@ -30,6 +31,7 @@ struct RunningProgressPage: View {
                     .font(.title1)
             }
             Button(action: {
+                selectedTab = 1
                 mapVM.stopUpdatingLocation()
             }, label: {
                 Image(systemName: "pause.circle")
@@ -43,5 +45,5 @@ struct RunningProgressPage: View {
 }
 
 #Preview {
-    RunningProgressPage(mapVM: MapViewModel())
+    RunningProgressPage(mapVM: MapViewModel(), selectedTab: .constant(0))
 }

--- a/RunUs/RunUs/View/Run/RunningProgressPage.swift
+++ b/RunUs/RunUs/View/Run/RunningProgressPage.swift
@@ -33,6 +33,7 @@ struct RunningProgressPage: View {
             Button(action: {
                 selectedTab = 1
                 mapVM.stopUpdatingLocation()
+                mapVM.isRunning = false
             }, label: {
                 Image(systemName: "pause.circle")
                     .resizable()

--- a/RunUs/RunUs/ViewModel/MapViewModel.swift
+++ b/RunUs/RunUs/ViewModel/MapViewModel.swift
@@ -7,10 +7,12 @@
 
 import CoreLocation
 import Foundation
+import NMapsMap
 
 class MapViewModel: NSObject, ObservableObject {
     private let locationManager: CLLocationManager
     @Published var userLocation: CLLocation?
+    @Published var userPath: [NMGLatLng] = []
     
     override init() {
         locationManager = CLLocationManager()
@@ -45,6 +47,7 @@ extension MapViewModel: CLLocationManagerDelegate {
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let newLocation = locations.last else { return }
         userLocation = newLocation
+        userPath.append(NMGLatLng(from: newLocation.coordinate))
     }
     
     func locationManager(_ manager: CLLocationManager, didFailWithError error: any Error) {

--- a/RunUs/RunUs/ViewModel/MapViewModel.swift
+++ b/RunUs/RunUs/ViewModel/MapViewModel.swift
@@ -8,8 +8,17 @@
 import CoreLocation
 import Foundation
 
-class MapViewModel: ObservableObject {
-    let locationManager = CLLocationManager()
+class MapViewModel: NSObject, ObservableObject {
+    private let locationManager: CLLocationManager
+    @Published var userLocation: CLLocation?
+    
+    override init() {
+        locationManager = CLLocationManager()
+        super.init()
+        locationManager.delegate = self
+        checkLocationPermission()
+        locationManager.startUpdatingLocation()
+    }
     
     func checkLocationPermission() {
         switch locationManager.authorizationStatus {
@@ -28,5 +37,17 @@ class MapViewModel: ObservableObject {
         default:
             break
         }
+    }
+}
+
+extension MapViewModel: CLLocationManagerDelegate {
+    // 사용자 위치 업데이트
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let newLocation = locations.last else { return }
+        userLocation = newLocation
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: any Error) {
+        print("error: ", error.localizedDescription)
     }
 }

--- a/RunUs/RunUs/ViewModel/MapViewModel.swift
+++ b/RunUs/RunUs/ViewModel/MapViewModel.swift
@@ -13,6 +13,7 @@ class MapViewModel: NSObject, ObservableObject {
     private let locationManager: CLLocationManager
     @Published var userLocation: CLLocation?
     @Published var userPath: [NMGLatLng] = []
+    @Published var isRunning: Bool = false
     
     override init() {
         locationManager = CLLocationManager()

--- a/RunUs/RunUs/ViewModel/MapViewModel.swift
+++ b/RunUs/RunUs/ViewModel/MapViewModel.swift
@@ -11,7 +11,7 @@ import NMapsMap
 
 class MapViewModel: NSObject, ObservableObject {
     private let locationManager: CLLocationManager
-    @Published var userLocation: CLLocation?
+    @Published var userLocation: CLLocation = CLLocation(latitude: 37.564214, longitude: 127.001699)
     @Published var userPath: [NMGLatLng] = []
     @Published var isRunning: Bool = false
     

--- a/RunUs/RunUs/ViewModel/MapViewModel.swift
+++ b/RunUs/RunUs/ViewModel/MapViewModel.swift
@@ -56,6 +56,7 @@ extension MapViewModel: CLLocationManagerDelegate {
     
     // 사용자 위치 추적 시작
     func startUpdatingLocation() {
+        isRunning = true
         locationManager.startUpdatingLocation()
     }
     

--- a/RunUs/RunUs/ViewModel/MapViewModel.swift
+++ b/RunUs/RunUs/ViewModel/MapViewModel.swift
@@ -19,7 +19,6 @@ class MapViewModel: NSObject, ObservableObject {
         super.init()
         locationManager.delegate = self
         checkLocationPermission()
-        locationManager.startUpdatingLocation()
     }
     
     func checkLocationPermission() {
@@ -52,5 +51,15 @@ extension MapViewModel: CLLocationManagerDelegate {
     
     func locationManager(_ manager: CLLocationManager, didFailWithError error: any Error) {
         print("error: ", error.localizedDescription)
+    }
+    
+    // 사용자 위치 추적 시작
+    func startUpdatingLocation() {
+        locationManager.startUpdatingLocation()
+    }
+    
+    // 사용자 위치 추적 멈춤
+    func stopUpdatingLocation() {
+        locationManager.stopUpdatingLocation()
     }
 }


### PR DESCRIPTION
<!-- PR 제목은 아래를 따라주세요!
	- [FEAT]: xxx화면 yy기능 개발
	- [FIX]: zzz버그 수정
	- [RELEASE]: alpha version 배포 -->

### 연관된 이슈를 적어주세요 📌
<!-- 연관된 이슈 번호를 모두 작성해 주세요. ex, #10, #11 -->
- #6 
- #15 
<br>

### 작업한 내용을 설명해주세요 ✔️
<!-- PR의 작업 내용에 대한 설명을 적습니다. 이런 내용이 변경되었어요! -->
- 지도 화면 진입 시 사용자 위치로 지도 이동
- 러닝을 시작하면 사용자 위치를 실시간으로 업데이트 후 경로선 추가 
- 일시정지, 계속하기 추가 (로직만, 통신 x)
- 진행상황 탭에서 일시정지 버튼을 누르면 지도 탭으로 이동 
- Picker로 진행상황 화면 두 개를 switch문으로 전환하던 것을 TabView를 사용하는 것으로 변경 

<br>

### 실행 화면
<!--
화면의 스크린샷 또는 영상을 같이 첨부해주세요.
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->

https://github.com/user-attachments/assets/616c8ed1-1540-4e2f-a1f0-b132a6c97338

<br>

### 발생한 이슈
<!-- 작업을 하며 발생했던 이슈, 이슈가 해결되었는지 또는 리뷰를 하며 참고할 점을 적어주세요. -->
- 커스텀 탭바 관련해서 `RunAlonePage.swift` 파일에 있는 `TabView`와 `selection`, `tag()` 를 참고하면 좋을 것 같아요 
<br>
