### PR TITLE
[FEAT] 자동로그인: 회원가입은 한 번만 하도록 수정 

### DIFF
--- a/RunUs/RunUs/View/MyPage.swift
+++ b/RunUs/RunUs/View/MyPage.swift
@@ -14,6 +14,7 @@ struct MyPage: View {
         VStack {
             Button(action: {
                 UserDefaults.standard.removeObject(forKey: "idToken")
+                UserDefaults.standard.removeObject(forKey: "userId")
                 dismiss()
             }, label: {
                 Text("로그아웃")

--- a/RunUs/RunUs/View/Onboarding/JoinPage.swift
+++ b/RunUs/RunUs/View/Onboarding/JoinPage.swift
@@ -8,11 +8,13 @@
 import SwiftUI
 
 struct JoinPage: View {
+    @Environment(\.dismiss) var dismiss
     @State private var nickname: String = ""
     @State private var email: String = ""
-    @State var joinSuccess: Bool = false
-    @ObservedObject var joinService: JoinService
+    @Binding var loginSuccess: Bool
+    @ObservedObject var joinService: JoinService = JoinService()
     let userInfo = UserDefaults.standard
+    
     var body: some View {
         NavigationView {
             Form {
@@ -31,8 +33,11 @@ struct JoinPage: View {
                     Button(action: {
                         print("닉네임 - \(nickname) : 이메일 - \(email)")
                         joinService.joinMembership(inputNickName: nickname, inputEmail: email) { success in
-                            userInfo.set(joinService.joinMemberInfo?.publicId, forKey: "userId")
-                            joinSuccess = success
+                            if success {
+                                userInfo.set(joinService.joinMemberInfo?.publicId, forKey: "userId")
+                                loginSuccess = true
+                                dismiss()
+                            }
                         }
                     }, label: {
                         Text("저장")
@@ -43,12 +48,9 @@ struct JoinPage: View {
             }
             .navigationBarTitle("정보 입력")
         }
-        .fullScreenCover(isPresented: $joinSuccess) {
-            MainPage()
-        }
     }
 }
 
 #Preview {
-    JoinPage(joinService: JoinService())
+    JoinPage(loginSuccess: .constant(false))
 }

--- a/RunUs/RunUs/View/Onboarding/LoginPage.swift
+++ b/RunUs/RunUs/View/Onboarding/LoginPage.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct LoginPage: View {
     @StateObject var authVM: AuthViewModel = AuthViewModel()
     @State private var loginSuccess: Bool = false
+    @State private var showJoinPage: Bool = false
     
     var body: some View {
         NavigationStack {
@@ -21,22 +22,25 @@ struct LoginPage: View {
                     .lineSpacing(0.8)
                 Button(action: {
                     authVM.kakaoLogin { isSuccess in
-                        loginSuccess = isSuccess
+                        showJoinPage = isSuccess
                     }
                 }, label: {
                     Image("kakao_login_button")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                 })
-                .fullScreenCover(isPresented: $loginSuccess) {
-                    JoinPage(joinService: JoinService())
+                .fullScreenCover(isPresented: $showJoinPage) {
+                    JoinPage(loginSuccess: $loginSuccess)
                 }
             }
             .padding(.horizontal, 20)
             .onAppear {
-                if authVM.checkTokenExists() {
+                if authVM.checkUserIdExists() {
                     loginSuccess = true
                 }
+            }
+            .fullScreenCover(isPresented: $loginSuccess) {
+                MainPage()
             }
         }
     }

--- a/RunUs/RunUs/ViewModel/AuthViewModel.swift
+++ b/RunUs/RunUs/ViewModel/AuthViewModel.swift
@@ -56,4 +56,12 @@ class AuthViewModel: ObservableObject {
         }
         return false
     }
+    
+    // 저장된 userId 존재 여부 확인
+    func checkUserIdExists() -> Bool {
+        if let userId = UserDefaults.standard.string(forKey: "userId") {
+            return true
+        }
+        return false
+    }
 }


### PR DESCRIPTION
<!-- PR 제목은 아래를 따라주세요!
	- [FEAT]: xxx화면 yy기능 개발
	- [FIX]: zzz버그 수정
	- [RELEASE]: alpha version 배포 -->

### 연관된 이슈를 적어주세요 📌
<!-- 연관된 이슈 번호를 모두 작성해 주세요. ex, #10, #11 -->
x

<br>

### 작업한 내용을 설명해주세요 ✔️
<!-- PR의 작업 내용에 대한 설명을 적습니다. 이런 내용이 변경되었어요! -->
- 기존에 idToken으로 로그인 상태를 관리하던 것을 userId로 관리하도록 변경
  - userId 존재 -> MainPage로 / userId 존재 x -> JoinPage로 
- JoinPage에서 회원가입 성공 시 
  - 기존: MainPage로 이동
  - 수정 후: loginSuccess 값 업데이트 후, dismiss로 JoinPage를 닫음

<br>

### 실행 화면
<!--
화면의 스크린샷 또는 영상을 같이 첨부해주세요.
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->
<br>

### 참고할 점 
<!-- 작업을 하며 발생했던 이슈, 이슈가 해결되었는지 또는 리뷰를 하며 참고할 점을 적어주세요. -->
JoinPage에서 MainPage로 이동하는 코드를 수정한 이유입니다. 
NavigationStack에 LoginPage 다음에 MainPage가 쌓여야 하므로 JoinPage에서 fullScreenCover가 아닌 dismiss로 화면을 없애주었습니다 ☺︎
<img width="860" alt="스크린샷 2024-10-04 21 18 25" src="https://github.com/user-attachments/assets/7811ba92-dc64-49da-9057-a71de52bae10">


<br>
