### PR TITLE
[FIX] stomp로 보내는 메세지의 인코딩 문제 해결

### DIFF
--- a/RunUs/RunUs/Model/RunningInfo.swift
+++ b/RunUs/RunUs/Model/RunningInfo.swift
@@ -27,3 +27,11 @@ struct Location: Codable {
     var x: Double
     var y: Double
 }
+
+struct RunningUpdateInfo: Codable {
+    var runningId: String
+    var userId: String
+    var latitude: Double
+    var longitude: Double
+    var count: Int
+}

--- a/RunUs/RunUs/View/GroupRun/StartGroupRunPage.swift
+++ b/RunUs/RunUs/View/GroupRun/StartGroupRunPage.swift
@@ -48,10 +48,13 @@ struct StartGroupRunPage: View {
             VStack {
                 TextField("인증코드", text: $joinCode)
                 HStack {
-                    Button(action: {}, label: {
+                    Button(action: {
+                        
+                    }, label: {
                         Text("취소")
                     })
                     Button(action: {
+                        joinGroup()
                         showJoinGroupRunPage = true
                     }, label: {
                         Text("참가하기")
@@ -78,6 +81,9 @@ struct StartGroupRunPage: View {
                 print("createRunningSession || error")
             }
         }
+    }
+    func joinGroup() {
+        WebSocketService.sharedSocket.connect(runningSessionInfo: nil, passcode: joinCode)
     }
         
 }

--- a/RunUs/RunUs/View/Run/RunningProgressPage.swift
+++ b/RunUs/RunUs/View/Run/RunningProgressPage.swift
@@ -39,6 +39,7 @@ struct RunningProgressPage: View {
             }
             Button(action: {
                 selectedTab = 1
+                WebSocketService.sharedSocket.sendMessagePause()
                 mapVM.stopUpdatingLocation()
                 mapVM.isRunning = false
             }, label: {


### PR DESCRIPTION
<!-- PR 제목은 아래를 따라주세요!
	- [FEAT]: xxx화면 yy기능 개발
	- [FIX]: zzz버그 수정
	- [RELEASE]: alpha version 배포 -->

### 연관된 이슈를 적어주세요 📌
<!-- 연관된 이슈 번호를 모두 작성해 주세요. ex, #10, #11 -->
- #<issue_num>

<br>

### 작업한 내용을 설명해주세요 ✔️
<!-- PR의 작업 내용에 대한 설명을 적습니다. 이런 내용이 변경되었어요! -->
- Pause 기능 추가
- Server에 보내는 메세지가 제대로 인코딩되지 않던 이슈 해결
- Stop 메세지 보내기 위한 함수 추가   

<br>

### 실행 화면
<!--
화면의 스크린샷 또는 영상을 같이 첨부해주세요.
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->
![RunUs_iOS_networkFlow](https://github.com/user-attachments/assets/490851e0-91ae-4ee8-88ef-d5013485f23b)
<br>

### 발생한 이슈
<!-- 작업을 하며 발생했던 이슈, 이슈가 해결되었는지 또는 리뷰를 하며 참고할 점을 적어주세요. -->

<br>
